### PR TITLE
Fix _xbgoost

### DIFF
--- a/colab/rapids-colab.sh
+++ b/colab/rapids-colab.sh
@@ -116,6 +116,8 @@ if [ ! -f Miniconda3-4.5.4-Linux-x86_64.sh ]; then
     cp /usr/local/lib/libcudf.so /usr/lib/libcudf.so
     cp /usr/local/lib/librmm.so /usr/lib/librmm.so
     cp /usr/local/lib/libnccl.so /usr/lib/libnccl.so
+    echo "Copying RAPIDS compatible xgboost"
+    cp /usr/local/lib/libxgboost.so /usr/lib/libxgboost.so
 fi
 
 echo ""


### PR DESCRIPTION
added a line to copy the xgboost shared object so that xgboost libraries will be found in Colab.  Solves https://github.com/rapidsai/rapidsai-csp-utils/issues/5

